### PR TITLE
Setup for running inside a docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.gitignore
+.travis.yml
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:10-buster-slim AS build
+
+WORKDIR /build
+ADD . /build
+
+RUN apt update && apt install --yes git binutils
+RUN npm install
+RUN npm run build
+
+FROM alpine:latest
+
+RUN apk add --update --no-cache lighttpd
+
+ADD lighttpd.conf /etc/lighttpd/lighttpd.conf
+COPY --from=build /build/dist /app
+
+EXPOSE 80
+
+ENTRYPOINT ["lighttpd", "-D"]
+CMD ["-f", "/etc/lighttpd/lighttpd.conf"]

--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -1,0 +1,12 @@
+server.port             = 80
+server.document-root    = "/app"
+server.errorlog         = "/dev/stdout"
+accesslog.filename      = "/dev/stdout"
+dir-listing.activate    = "disable"
+server.modules          = (
+                            "mod_access",
+                            "mod_accesslog",
+                            )
+include                 "mime-types.conf"
+server.pid-file         = "/run/lighttpd.pid"
+index-file.names = ( "index.html", "index.htm" )


### PR DESCRIPTION
This PR adds a ```Dockerfile``` and uses ```lighttpd``` to serve the static pages built by ```npm run build```.

The following can be used to build/run the container based on these sources.

``` sh

docker build -t sengi:latest .
docker run -it --name sengi \
    --restart unless-stopped \
    --network docker-private \
    -e TZ=UTC \
    -e DEBUG=1 \
    -l traefik.frontend.rule=Host:domain.tld \
    -l traefik.frontend.passHostHeader=true \
    -l traefik.port=80 \
    sengi:latest

```