### PR TITLE
Add installation instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Find more informations [here](https://github.com/NicolasConstant/sengi/blob/mast
 The docker image also provide a landing page so that you can open a pop-up really easily. <br />
 It's available in ```https://your-host/start/index.html```
 
+## Installation
+
+### macOS
+
+Sengi is available in Homebrew. You can install the latest version of Sengi with the following command:
+
+```
+brew install --cask sengi
+```
+
 ## Contact
 
   * [Official Sengi Account](https://mastodon.social/@sengi_app)


### PR DESCRIPTION
```
# brew info sengi
sengi: 1.0.3
https://github.com/NicolasConstant/sengi
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/sengi.rb
==> Name
Sengi
==> Description
Mastodon and Pleroma desktop client
==> Artifacts
Sengi.app (App)
==> Analytics
install: 0 (30 days), 0 (90 days), 0 (365 days)
```
Refs https://github.com/Homebrew/homebrew-cask/pull/98773