### PR TITLE
use /api/v1/statuses/ for status lookup instead of search

### DIFF
--- a/src/app/components/stream/status/action-bar/status-user-context-menu/status-user-context-menu.component.ts
+++ b/src/app/components/stream/status/action-bar/status-user-context-menu/status-user-context-menu.component.ts
@@ -286,16 +286,7 @@ export class StatusUserContextMenuComponent implements OnInit, OnDestroy {
         let statusPromise: Promise<Status> = Promise.resolve(this.statusWrapper.status);
 
         if (account.id !== this.statusWrapper.provider.id) {
-            statusPromise =
-                this.toolsService.getInstanceInfo(account)
-                    .then(instance => {
-                        let version: 'v1' | 'v2' = 'v1';
-                        if (instance.major >= 3) version = 'v2';
-                        return this.mastodonService.search(account, this.statusWrapper.status.url, version, true);
-                    })
-                    .then((result: Results) => {
-                        return result.statuses[0];
-                    });
+            statusPromise = this.mastodonService.getStatus(this.statusWrapper.status.id);
         }
 
         return statusPromise;

--- a/src/app/components/stream/thread/thread.component.ts
+++ b/src/app/components/stream/thread/thread.component.ts
@@ -157,23 +157,8 @@ export class ThreadComponent extends BrowseBase {
         if (status.visibility === 'public' || status.visibility === 'unlisted') {
             // var statusPromise: Promise<Status> = Promise.resolve(status);
             // if (!sourceAccount || sourceAccount.id !== currentAccount.id) {
-            var statusPromise = this.toolsService.getInstanceInfo(currentAccount)
-                    .then(instance => {
-                        let version: 'v1' | 'v2' = 'v1';
-                        if (instance.major >= 3) version = 'v2';
-                        return this.mastodonService.search(currentAccount, status.uri, version, true);
-                    })
-                    .then((result: Results) => {
-                        if (result.statuses.length === 1) {
-                            const retrievedStatus = result.statuses[0];
-                            return retrievedStatus;
-                        }
-                        throw new Error('could not find status');
-                    });
-            // }
-
+            var statusPromise = this.mastodonService.getStatus(currentAccount, status.id);
             this.retrieveThread(currentAccount, statusPromise);
-
         } else if (sourceAccount && sourceAccount.id === currentAccount.id) {
             var statusPromise = Promise.resolve(status);
             this.retrieveThread(currentAccount, statusPromise);

--- a/src/app/services/tools.service.ts
+++ b/src/app/services/tools.service.ts
@@ -176,21 +176,7 @@ export class ToolsService {
         if (!isProvider) {
             statusPromise = statusPromise
                 .then((foreignStatus: Status) => {
-                    const statusUri = foreignStatus.uri;
-                    const statusUrl = foreignStatus.url;                    
-                    return this.getInstanceInfo(account)
-                        .then(instance => {
-                            let version: 'v1' | 'v2' = 'v1';
-                            if (instance.major >= 3) version = 'v2';
-                            return this.mastodonService.search(account, statusUri, version, true)
-                                .then((results: Results) => {
-                                    if(results && results.statuses.length > 0) return results;
-                                    return this.mastodonService.search(account, statusUrl, version, true);
-                                });
-                        })
-                        .then((results: Results) => {
-                            return results.statuses[0];
-                        });
+                    return this.mastodonService.getStatus(foreignStatus.id);
                 });
         }
 


### PR DESCRIPTION
Pleroma search is terrible. Even with resolve=true and passing a direct URL, it will still attempt a fulltext search in addition to a URL fetch. On many instances, search is so slow that any fulltext search simply times out after 15 seconds, which would cause all post lookups to fail in Sengi. As the search API is intended for "cold" lookups only, this PR switches to the dedicated status lookup endpoint.

This works on both Pleroma and Mastodon. However, I removed some Error handling, so I'm not sure what would happen if attempting to open a post that has since been deleted. I tried to test that, but as Sengi uses WebSocket streaming, as soon as I deleted a post in a separate client, the deletion was reflected in Sengi.