### PR TITLE
hashtag following support for mastodon >= 4.0

### DIFF
--- a/src/app/components/stream/hashtag/hashtag.component.html
+++ b/src/app/components/stream/hashtag/hashtag.component.html
@@ -2,15 +2,16 @@
     <div class="hashtag-header">
         <a href (click)="goToTop()" class="hashtag-header__gototop" title="go to top">
             <h3 class="hashtag-header__title">#{{hashtagElement.tag}}</h3>
-
+            <button *ngIf="isHashtagFollowingAvailable && !isFollowingHashtag" class="btn-custom-secondary hashtag-header__follow-button" (click)="followThisHashtag($event)" title="follow hashtag" [disabled]="followingLoading">follow</button>
+            <button *ngIf="isHashtagFollowingAvailable && isFollowingHashtag" class="btn-custom-secondary hashtag-header__follow-button" (click)="unfollowThisHashtag($event)" title="unfollow hashtag" [disabled]="unfollowingLoading">unfollow</button>
             <button class="btn-custom-secondary hashtag-header__add-column" (click)="addColumn($event)" title="add column to board" [hidden]="columnAdded">add column</button>
         </a>
     </div>
-    <app-stream-statuses #appStreamStatuses class="hashtag-stream" *ngIf="hashtagElement" 
-        [streamElement]="hashtagElement" 
+    <app-stream-statuses #appStreamStatuses class="hashtag-stream" *ngIf="hashtagElement"
+        [streamElement]="hashtagElement"
         [goToTop]="goToTopSubject.asObservable()"
         [userLocked]="false"
-        (browseAccountEvent)="browseAccount($event)" 
+        (browseAccountEvent)="browseAccount($event)"
         (browseHashtagEvent)="browseHashtag($event)"
         (browseThreadEvent)="browseThread($event)"></app-stream-statuses>
 </div>

--- a/src/app/components/stream/hashtag/hashtag.component.scss
+++ b/src/app/components/stream/hashtag/hashtag.component.scss
@@ -40,6 +40,14 @@ $inner-column-size: 320px;
         border: 1px solid black;
         color: white;
     }
+    &__follow-button {
+        position: absolute;
+        top: 7px;
+        right: 100px;
+        padding: 0 10px 0 10px;
+        border: 1px solid black;
+        color: white;
+    }
 }
 
 .hashtag-stream {

--- a/src/app/services/mastodon-wrapper.service.ts
+++ b/src/app/services/mastodon-wrapper.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngxs/store';
 
-import { Account, Status, Results, Context, Relationship, Instance, Attachment, Notification, List, Poll, Emoji, Conversation, ScheduledStatus, TokenData } from "./models/mastodon.interfaces";
+import { Account, Status, Results, Context, Relationship, Instance, Attachment, Notification, List, Poll, Emoji, Conversation, ScheduledStatus, TokenData, Tag } from "./models/mastodon.interfaces";
 import { AccountInfo, UpdateAccount } from '../states/accounts.state';
 import { StreamTypeEnum, StreamElement } from '../states/streams.state';
 import { FavoriteResult, VisibilityEnum, PollParameters, MastodonService, BookmarkResult, FollowingResult } from './mastodon.service';
@@ -12,7 +12,7 @@ import { SettingsService } from './settings.service';
 @Injectable({
     providedIn: 'root'
 })
-export class MastodonWrapperService {    
+export class MastodonWrapperService {
     private refreshingToken: { [id: string]: Promise<AccountInfo> } = {};
 
     constructor(
@@ -29,7 +29,7 @@ export class MastodonWrapperService {
         let isExpired = false;
         let storedAccountInfo = this.getStoreAccountInfo(accountInfo.id);
 
-        if(!storedAccountInfo || !(storedAccountInfo.token)) 
+        if(!storedAccountInfo || !(storedAccountInfo.token))
             return Promise.resolve(accountInfo);
 
         try {
@@ -39,7 +39,7 @@ export class MastodonWrapperService {
                 } else {
                     const nowEpoch = Date.now() / 1000 | 0;
 
-                    //Pleroma workaround 
+                    //Pleroma workaround
                     let expire_in = storedAccountInfo.token.expires_in;
                     if (expire_in < 3600) {
                         expire_in = 3600;
@@ -74,7 +74,7 @@ export class MastodonWrapperService {
             p.then(() => {
                 this.refreshingToken[accountInfo.id] = null;
             });
-            
+
             this.refreshingToken[accountInfo.id] = p;
             return p;
         } else {
@@ -264,6 +264,27 @@ export class MastodonWrapperService {
         return this.refreshAccountIfNeeded(currentlyUsedAccount)
             .then((refreshedAccount: AccountInfo) => {
                 return this.mastodonService.unfollow(refreshedAccount, account);
+            });
+    }
+
+    followHashtag(currentlyUsedAccount: AccountInfo, hashtag: string): Promise<Tag> {
+        return this.refreshAccountIfNeeded(currentlyUsedAccount)
+            .then((refreshedAccount: AccountInfo) => {
+                return this.mastodonService.followHashtag(refreshedAccount, hashtag);
+            });
+    }
+
+    unfollowHashtag(currentlyUsedAccount: AccountInfo, hashtag: string): Promise<Tag> {
+        return this.refreshAccountIfNeeded(currentlyUsedAccount)
+            .then((refreshedAccount: AccountInfo) => {
+                return this.mastodonService.unfollowHashtag(refreshedAccount, hashtag);
+            });
+    }
+
+    getHashtag(currentlyUsedAccount: AccountInfo, hashtag: string): Promise<Tag> {
+        return this.refreshAccountIfNeeded(currentlyUsedAccount)
+            .then((refreshedAccount: AccountInfo) => {
+                return this.mastodonService.getHashtag(refreshedAccount, hashtag);
             });
     }
 

--- a/src/app/services/mastodon.service.ts
+++ b/src/app/services/mastodon.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpHeaders, HttpClient, HttpResponse } from '@angular/common/http';
 
 import { ApiRoutes } from './models/api.settings';
-import { Account, Status, Results, Context, Relationship, Instance, Attachment, Notification, List, Poll, Emoji, Conversation, ScheduledStatus } from "./models/mastodon.interfaces";
+import { Account, Status, Results, Context, Relationship, Instance, Attachment, Notification, List, Poll, Emoji, Conversation, ScheduledStatus, Tag } from "./models/mastodon.interfaces";
 import { AccountInfo } from '../states/accounts.state';
 import { StreamTypeEnum, StreamElement } from '../states/streams.state';
 
@@ -289,6 +289,24 @@ export class MastodonService {
 
     }
 
+    followHashtag(currentlyUsedAccount: AccountInfo, hashtag: string): Promise<Tag> {
+        const route = `https://${currentlyUsedAccount.instance}${this.apiRoutes.followHashtag}`.replace('{0}', hashtag);
+        const headers = new HttpHeaders({ 'Authorization': `Bearer ${currentlyUsedAccount.token.access_token}` });
+        return this.httpClient.post<Tag>(route, null, { headers: headers }).toPromise();
+    }
+
+    unfollowHashtag(currentlyUsedAccount: AccountInfo, hashtag: string): Promise<Tag> {
+        const route = `https://${currentlyUsedAccount.instance}${this.apiRoutes.unfollowHashtag}`.replace('{0}', hashtag);
+        const headers = new HttpHeaders({ 'Authorization': `Bearer ${currentlyUsedAccount.token.access_token}` });
+        return this.httpClient.post<Tag>(route, null, { headers: headers }).toPromise();
+    }
+
+    getHashtag(currentlyUsedAccount: AccountInfo, hashtag: string): Promise<Tag> {
+        const route = `https://${currentlyUsedAccount.instance}${this.apiRoutes.getHashtag}`.replace('{0}', hashtag);
+        const headers = new HttpHeaders({ 'Authorization': `Bearer ${currentlyUsedAccount.token.access_token}` });
+        return this.httpClient.get<Tag>(route, { headers: headers }).toPromise();
+    }
+
     uploadMediaAttachment(account: AccountInfo, file: File, description: string): Promise<Attachment> {
         let input = new FormData();
         input.append('file', file);
@@ -382,10 +400,10 @@ export class MastodonService {
     addAccountToList(account: AccountInfo, listId: string, accountId: number): Promise<any> {
         let route = `https://${account.instance}${this.apiRoutes.addAccountToList}`.replace('{0}', listId);
         route += `?account_ids[]=${accountId}`;
-        
+
         let data = new ListAccountData();
         data.account_ids.push(accountId.toString());
-        
+
         const headers = new HttpHeaders({ 'Authorization': `Bearer ${account.token.access_token}` });
         return this.httpClient.post(route, data, { headers: headers }).toPromise();
     }

--- a/src/app/services/models/api.settings.ts
+++ b/src/app/services/models/api.settings.ts
@@ -75,4 +75,7 @@ export class ApiRoutes {
     getBookmarks = '/api/v1/bookmarks';
     getFollowers = '/api/v1/accounts/{0}/followers';
     getFollowing = '/api/v1/accounts/{0}/following';
+    followHashtag = '/api/v1/tags/{0}/follow';
+    unfollowHashtag = '/api/v1/tags/{0}/unfollow';
+    getHashtag = '/api/v1/tags/{0}';
 }

--- a/src/app/services/models/mastodon.interfaces.ts
+++ b/src/app/services/models/mastodon.interfaces.ts
@@ -141,7 +141,7 @@ export interface Relationship {
     id: number;
     following: boolean;
     followed_by: boolean;
-    blocked_by: boolean;    
+    blocked_by: boolean;
     blocking: boolean;
     domain_blocking: boolean;
     muting: boolean;
@@ -190,7 +190,7 @@ export interface Status {
     muted: boolean;
     bookmarked: boolean;
     card: Card;
-    poll: Poll;    
+    poll: Poll;
 
     pleroma: PleromaStatusInfo;
 }
@@ -249,4 +249,17 @@ export interface StatusParams {
     visibility: 'public' | 'unlisted' | 'private' | 'direct';
     scheduled_at: string;
     application_id: string;
+}
+
+export interface TagHistory {
+    day: string;
+    uses: number;
+    accounts: number;
+}
+
+export interface Tag {
+    name: string;
+    url: string;
+    history: TagHistory[];
+    following: boolean;
 }


### PR DESCRIPTION
Proposed implementation for #470 

This adds a "follow"/"unfollow" button next to the "add column" button when viewing a hashtag timeline, so long as the active account is on a 4.x mastodon server.

![Screenshot 2022-11-18 201929](https://user-images.githubusercontent.com/207173/202832172-067b6cae-c1b2-492c-9884-41082e697ec7.png)
![Screenshot 2022-11-18 201947](https://user-images.githubusercontent.com/207173/202832174-90fc23b2-2020-4097-81b9-7c5c46bf9f11.png)

I'm pretty new to angular and frontend development, so feedback is welcome!