### PR TITLE
fix new item count in slow mode

### DIFF
--- a/src/app/components/stream/stream-statuses/stream-statuses.component.html
+++ b/src/app/components/stream/stream-statuses/stream-statuses.component.html
@@ -5,18 +5,18 @@
         </a>
     </div>
 
-    <div class="stream-toots__new-notification" 
+    <div class="stream-toots__new-notification"
         [class.stream-toots__new-notification--display]="bufferStream && bufferStream.length > 0 && !streamPositionnedAtTop"></div>
 
-    <div class="stream-toots__content flexcroll" #statusstream (scroll)="onScroll()" tabindex="0">       
+    <div class="stream-toots__content flexcroll" #statusstream (scroll)="onScroll()" tabindex="0">
         <div *ngIf="displayError" class="stream-toots__error">{{displayError}}</div>
 
-        <div *ngIf="timelineLoadingMode === 3 && bufferStream && bufferStream.length > 0">
-            <a href (click)="loadBuffer()" class="stream-toots__load-buffer" title="load new items">{{ bufferStream.length }} new item<span *ngIf="bufferStream.length > 1">s</span></a>
+        <div *ngIf="timelineLoadingMode === 3 && bufferStream && numNewItems > 0">
+            <a href (click)="loadBuffer()" class="stream-toots__load-buffer" title="load new items">{{ numNewItems }} new item<span *ngIf="numNewItems > 1">s</span></a>
         </div>
 
         <div class="stream-toots__status" *ngFor="let statusWrapper of statuses" #status>
-            <app-status 
+            <app-status
                 [statusWrapper]="statusWrapper" [isThreadDisplay]="isThread"
                 (browseAccountEvent)="browseAccount($event)" (browseHashtagEvent)="browseHashtag($event)"
                 (browseThreadEvent)="browseThread($event)"></app-status>

--- a/src/app/components/stream/stream-statuses/stream-statuses.component.ts
+++ b/src/app/components/stream/stream-statuses/stream-statuses.component.ts
@@ -43,6 +43,8 @@ export class StreamStatusesComponent extends TimelineBase {
     private deleteStatusSubscription: Subscription;
     private streams$: Observable<StreamElement[]>;
 
+    numNewItems: number;
+
     constructor(
         protected readonly settingsService: SettingsService,
         protected readonly store: Store,
@@ -101,6 +103,8 @@ export class StreamStatusesComponent extends TimelineBase {
                 });
             }
         });
+
+        this.numNewItems = 0;
     }
 
     ngOnDestroy() {
@@ -133,6 +137,7 @@ export class StreamStatusesComponent extends TimelineBase {
     private resetStream() {
         this.statuses.length = 0;
         this.bufferStream.length = 0;
+        this.numNewItems = 0;
         if (this.websocketStreaming) this.websocketStreaming.dispose();
     }
 
@@ -154,6 +159,7 @@ export class StreamStatusesComponent extends TimelineBase {
                             this.statuses.unshift(wrapper);
                         } else {
                             this.bufferStream.push(update.status);
+                            this.numNewItems++;
                         }
                     }
                 } else if (update.type === EventEnum.delete) {
@@ -201,6 +207,7 @@ export class StreamStatusesComponent extends TimelineBase {
         }
 
         this.bufferStream.length = 0;
+        this.numNewItems = 0;
         return false;
     }
 
@@ -212,7 +219,7 @@ export class StreamStatusesComponent extends TimelineBase {
                 return status.filter(x => !this.isFiltered(x));
             });
     }
-    
+
     private isFiltered(status: Status): boolean {
         if (this.streamElement.hideBoosts) {
             if (status.reblog) {


### PR DESCRIPTION
Currently when slow mode is enabled, the size of the buffer is used for displaying the count of new items since the last manual load. Unfortunately the buffer seems to have a max size of 60 items, and upon hitting 60 it jumps down to 40.

![Screenshot 2022-11-26 135320](https://user-images.githubusercontent.com/207173/204108529-5c06fff4-77f8-405f-b979-4a897209b7f9.png)

This PR tracks the new item count separately from the amount of status items currently in the buffer, so the user knows how many posts there have been since the last manual load.

![Screenshot 2022-11-26 135340](https://user-images.githubusercontent.com/207173/204108534-94682cdf-ed7d-49ad-8731-2507f0821a37.png)

This is a partial fix for #469. It does not change the current manual load behavior, which is to jump to the latest post, it only changes the new item count that's displayed before manual loading.