### PR TITLE
Fix some emojis not rendering correctly

### DIFF
--- a/src/app/tools/emoji.tools.ts
+++ b/src/app/tools/emoji.tools.ts
@@ -31,12 +31,12 @@ export class EmojiConverter {
     }
 
     private applyEmojiOne(className: string, text: string): string{
-        text = EmojiOne.toImage(text);
+        text = EmojiOne.shortnameToImage(text);
 
         while (text.includes('class="emojione"')) {
           text = text.replace('class="emojione"', `class="emojione ${className}"`);
         }
-    
+
         while (
           text.includes("https://cdn.jsdelivr.net/emojione/assets/4.5/png/32/")
         ) {


### PR DESCRIPTION
EmojiOne is being used to convert shortcodes to emojis, which works fine, but it's also attempting to convert unicode emojis to images which seems to be breaking certain emojis. I tried to file a ticket against EmojiOne, but it appears the project has either been abandoned recently or deprecated.

One such example is 🏳️‍⚧️ which is displayed as 
![image](https://user-images.githubusercontent.com/207173/204210199-2f194e5b-07ca-478f-942a-b1fffef1096d.png)

This PR changes the EmojiConverter to only use EmojiOne for converting shortcodes, since unicode works fine most everywhere without needing conversion.